### PR TITLE
Resolve conflict in upstream PR #1778

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/mimikatz.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/mimikatz.rb
@@ -109,7 +109,7 @@ class Console::CommandDispatcher::Mimikatz
 			table << [acc[:authid], acc[:package], acc[:domain], acc[:user],  acc[:password]]
 		end
 
-		print_line table.to_s
+		print_status table.to_s
 
 		return true
 	end


### PR DESCRIPTION
This should resolve rapid7/metasploit-framework#1778 's conflicted state. @Meatballs1 used print_line, @jlee-r7 used print_status, and intra-line diffs will tend to cause conflicts like this.
