### PR TITLE
Reverse listener comm improvements

### DIFF
--- a/lib/msf/core/handler.rb
+++ b/lib/msf/core/handler.rb
@@ -28,6 +28,7 @@ module Msf
 #
 ###
 module Handler
+  require 'msf/core/handler/reverse'
 
   ##
   #

--- a/lib/msf/core/handler/reverse.rb
+++ b/lib/msf/core/handler/reverse.rb
@@ -1,8 +1,34 @@
 module Msf
   module Handler
+    # Options and methods needed for all handlers that listen for a connection
+    # from the payload.
     module Reverse
       autoload :Comm, 'msf/core/handler/reverse/comm'
       autoload :SSL, 'msf/core/handler/reverse/ssl'
+
+      def initialize(info = {})
+        super
+
+        register_options(
+          [
+            Opt::LHOST,
+            Opt::LPORT(4444)
+          ], Msf::Handler::Reverse)
+
+        register_advanced_options(
+          [
+            OptPort.new('ReverseListenerBindPort', [false, 'The port to bind to on the local system if different from LPORT']),
+            OptBool.new('ReverseAllowProxy', [ true, 'Allow reverse tcp even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST', false]),
+          ], Msf::Handler::Reverse
+        )
+      end
+
+      # @return [Integer]
+      def bind_port
+        port = datastore['ReverseListenerBindPort'].to_i
+        port > 0 ? port : datastore['LPORT'].to_i
+      end
+
     end
   end
 end

--- a/lib/msf/core/handler/reverse.rb
+++ b/lib/msf/core/handler/reverse.rb
@@ -1,0 +1,8 @@
+module Msf
+  module Handler
+    module Reverse
+      autoload :Comm, 'msf/core/handler/reverse/comm'
+      autoload :SSL, 'msf/core/handler/reverse/ssl'
+    end
+  end
+end

--- a/lib/msf/core/handler/reverse.rb
+++ b/lib/msf/core/handler/reverse.rb
@@ -23,12 +23,79 @@ module Msf
         )
       end
 
+      # A list of addresses to attempt to bind, in preferred order.
+      #
+      # @return [Array<String>] a two-element array. The first element will be
+      #   the address that `datastore['LHOST']` resolves to, the second will
+      #   be the INADDR_ANY address for IPv4 or IPv6, depending on the version
+      #   of the first element.
+      def bind_addresses
+        # Switch to IPv6 ANY address if the LHOST is also IPv6
+        addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
+        # First attempt to bind LHOST. If that fails, the user probably has
+        # something else listening on that interface. Try again with ANY_ADDR.
+        any = (addr.length == 4) ? "0.0.0.0" : "::0"
+
+        addrs = [ Rex::Socket.addr_ntoa(addr), any  ]
+
+        if not datastore['ReverseListenerBindAddress'].to_s.empty?
+          # Only try to bind to this specific interface
+          addrs = [ datastore['ReverseListenerBindAddress'] ]
+
+          # Pick the right "any" address if either wildcard is used
+          addrs[0] = any if (addrs[0] == "0.0.0.0" or addrs == "::0")
+        end
+
+        addrs
+      end
+
       # @return [Integer]
       def bind_port
         port = datastore['ReverseListenerBindPort'].to_i
         port > 0 ? port : datastore['LPORT'].to_i
       end
 
+      #
+      # Starts the listener but does not actually attempt
+      # to accept a connection.  Throws socket exceptions
+      # if it fails to start the listener.
+      #
+      def setup_handler
+        if datastore['Proxies'] and not datastore['ReverseAllowProxy']
+          raise RuntimeError, "TCP connect-back payloads cannot be used with Proxies. Use 'set ReverseAllowProxy true' to override this behaviour."
+        end
+
+        ex = false
+
+        comm = select_comm
+        local_port = bind_port
+
+        bind_addresses.each do |ip|
+          begin
+            self.listener_sock = Rex::Socket::TcpServer.create(
+              'LocalHost' => ip,
+              'LocalPort' => local_port,
+              'Comm'      => comm,
+              'Context'   =>
+              {
+                'Msf'        => framework,
+                'MsfPayload' => self,
+                'MsfExploit' => assoc_exploit
+              })
+          rescue
+            ex = $!
+            print_error("Handler failed to bind to #{ip}:#{local_port}:- #{comm} -")
+          else
+            ex = false
+
+            via = via_string_for_ip(ip, comm)
+            print_status("Started #{human_name} handler on #{ip}:#{local_port} #{via}")
+
+            break
+          end
+        end
+        raise ex if (ex)
+      end
     end
   end
 end

--- a/lib/msf/core/handler/reverse/comm.rb
+++ b/lib/msf/core/handler/reverse/comm.rb
@@ -3,13 +3,14 @@ require 'rex/socket'
 
 module Msf
 module Handler
+module Reverse
 
 ###
 #
-# This module implements the reverse Rex::Socket::Comm handlng.
+# Implements the reverse Rex::Socket::Comm handlng.
 #
 ###
-module ReverseTcpComm
+module Comm
 
   def initialize(info = {})
     super
@@ -17,7 +18,7 @@ module ReverseTcpComm
     register_advanced_options(
       [
         OptString.new('ReverseListenerComm', [ false, 'The specific communication channel to use for this listener']),
-      ], Msf::Handler::ReverseTcpComm)
+      ], Msf::Handler::Reverse::Comm)
   end
 
   def select_comm
@@ -39,5 +40,6 @@ module ReverseTcpComm
   end
 end
 
+end
 end
 end

--- a/lib/msf/core/handler/reverse/comm.rb
+++ b/lib/msf/core/handler/reverse/comm.rb
@@ -38,6 +38,21 @@ module Comm
 
     comm
   end
+
+  def via_string_for_ip(ip, comm)
+    comm_used = comm
+    comm_used ||= Rex::Socket::SwitchBoard.best_comm(ip)
+    comm_used ||= Rex::Socket::Comm::Local
+
+    if comm_used.respond_to?(:type) && comm_used.respond_to?(:sid)
+      via = "via the #{comm_used.type} on session #{comm_used.sid}"
+    else
+      via = ""
+    end
+
+    via
+  end
+
 end
 
 end

--- a/lib/msf/core/handler/reverse/ssl.rb
+++ b/lib/msf/core/handler/reverse/ssl.rb
@@ -1,0 +1,19 @@
+module Msf
+  module Handler
+    module Reverse
+      module SSL
+        #
+        # Adds the certificate option.
+        #
+        def initialize(info = {})
+          super
+          register_advanced_options(
+            [
+              OptPath.new('HandlerSSLCert', [false, "Path to a SSL certificate in unified PEM format"])
+            ], Msf::Handler::Reverse::SSL)
+
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -20,7 +20,6 @@ module ReverseHttp
   include Msf::Handler
   include Rex::Payloads::Meterpreter::UriChecksum
   include Msf::Payload::Windows::VerifySsl
-  include Msf::Handler::Reverse::Comm
 
   #
   # Returns the string representation of the handler type
@@ -130,7 +129,6 @@ module ReverseHttp
   #
   def setup_handler
 
-    comm = select_comm
     local_port = bind_port
 
     # Start the HTTPS server service on this host/port
@@ -142,7 +140,7 @@ module ReverseHttp
         'Msf'        => framework,
         'MsfExploit' => self,
       },
-      comm,
+      nil,
       (ssl?) ? datastore['HandlerSSLCert'] : nil
     )
 
@@ -158,9 +156,7 @@ module ReverseHttp
       },
       'VirtualDirectory' => true)
 
-    via = via_string_for_ip(ip, comm)
-
-    print_status("Started #{scheme.upcase} reverse handler on #{listener_uri} #{via}")
+    print_status("Started #{scheme.upcase} reverse handler on #{listener_uri}")
     lookup_proxy_settings
 
     if datastore['IgnoreUnknownPayloads']

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -158,14 +158,7 @@ module ReverseHttp
       },
       'VirtualDirectory' => true)
 
-    comm_used = comm || Rex::Socket::SwitchBoard.best_comm( ip )
-    comm_used = Rex::Socket::Comm::Local if comm_used == nil
-
-    if( comm_used.respond_to?( :type ) and comm_used.respond_to?( :sid ) )
-      via = "via the #{comm_used.type} on session #{comm_used.sid}"
-    else
-      via = ""
-    end
+    via = via_string_for_ip(ip, comm)
 
     print_status("Started #{scheme.upcase} reverse handler on #{listener_uri} #{via}")
     lookup_proxy_settings

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -18,6 +18,7 @@ module Handler
 module ReverseHttp
 
   include Msf::Handler
+  include Msf::Handler::Reverse
   include Rex::Payloads::Meterpreter::UriChecksum
   include Msf::Payload::Windows::VerifySsl
 
@@ -54,7 +55,6 @@ module ReverseHttp
         OptString.new('MeterpreterUserAgent', [false, 'The user-agent that the payload should use for communication', Rex::UserAgent.shortest]),
         OptString.new('MeterpreterServerName', [false, 'The server header that the handler will send in response to requests', 'Apache']),
         OptAddress.new('ReverseListenerBindAddress', [false, 'The specific IP address to bind to on the local system']),
-        OptInt.new('ReverseListenerBindPort', [false, 'The port to bind to on the local system if different from LPORT']),
         OptBool.new('OverrideRequestHost', [false, 'Forces a specific host and port instead of using what the client requests, defaults to LHOST:LPORT', false]),
         OptString.new('OverrideLHOST', [false, 'When OverrideRequestHost is set, use this value as the host name for secondary requests']),
         OptPort.new('OverrideLPORT', [false, 'When OverrideRequestHost is set, use this value as the port number for secondary requests']),
@@ -392,13 +392,6 @@ protected
 
     # Force this socket to be closed
     obj.service.close_client( cli )
-  end
-
-protected
-
-  def bind_port
-    port = datastore['ReverseListenerBindPort'].to_i
-    port > 0 ? port : datastore['LPORT'].to_i
   end
 
 end

--- a/lib/msf/core/handler/reverse_https.rb
+++ b/lib/msf/core/handler/reverse_https.rb
@@ -13,6 +13,7 @@ module Handler
 ###
 module ReverseHttps
 
+  include Msf::Handler::Reverse::SSL
   include Msf::Handler::ReverseHttp
 
   #
@@ -43,7 +44,6 @@ module ReverseHttps
 
     register_advanced_options(
       [
-        OptPath.new('HandlerSSLCert', [false, "Path to a SSL certificate in unified PEM format"]),
         OptBool.new('StagerVerifySSLCert', [false, "Whether to verify the SSL certificate in Meterpreter"])
       ], Msf::Handler::ReverseHttps)
 

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -18,6 +18,7 @@ module Handler
 module ReverseTcp
 
   include Msf::Handler
+  include Msf::Handler::Reverse
   include Msf::Handler::Reverse::Comm
 
   #
@@ -43,19 +44,11 @@ module ReverseTcp
   def initialize(info = {})
     super
 
-    register_options(
-      [
-        Opt::LHOST,
-        Opt::LPORT(4444)
-      ], Msf::Handler::ReverseTcp)
-
     # XXX: Not supported by all modules
     register_advanced_options(
       [
         OptInt.new('ReverseConnectRetries', [ true, 'The number of connection attempts to try before exiting the process', 5 ]),
         OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
-        OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ]),
-        OptBool.new('ReverseAllowProxy', [ true, 'Allow reverse tcp even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST', false]),
         OptBool.new('ReverseListenerThreaded', [ true, 'Handle every connection in a new thread (experimental)', false])
       ], Msf::Handler::ReverseTcp)
 
@@ -248,11 +241,6 @@ module ReverseTcp
   end
 
 protected
-
-  def bind_port
-    port = datastore['ReverseListenerBindPort'].to_i
-    port > 0 ? port : datastore['LPORT'].to_i
-  end
 
   def bind_address
     # Switch to IPv6 ANY address if the LHOST is also IPv6

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -20,7 +20,7 @@ module Handler
 module ReverseTcp
 
   include Msf::Handler
-  include Msf::Handler::ReverseTcpComm
+  include Msf::Handler::Reverse::Comm
 
   #
   # Returns the string representation of the handler type, in this case
@@ -76,10 +76,7 @@ module ReverseTcp
 
     ex = false
 
-    # Identify the comm to use from
-    # Msf::Handler::ReverseTcpComm.select_comm
     comm = select_comm
-
     local_port = bind_port
     addrs = bind_address
 

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -55,49 +55,6 @@ module ReverseTcp
     self.conn_threads = []
   end
 
-  #
-  # Starts the listener but does not actually attempt
-  # to accept a connection.  Throws socket exceptions
-  # if it fails to start the listener.
-  #
-  def setup_handler
-    if datastore['Proxies'] and not datastore['ReverseAllowProxy']
-      raise RuntimeError, "TCP connect-back payloads cannot be used with Proxies. Use 'set ReverseAllowProxy true' to override this behaviour."
-    end
-
-    ex = false
-
-    comm = select_comm
-    local_port = bind_port
-    addrs = bind_address
-
-    addrs.each { |ip|
-      begin
-
-        self.listener_sock = Rex::Socket::TcpServer.create(
-          'LocalHost' => ip,
-          'LocalPort' => local_port,
-          'Comm'      => comm,
-          'Context'   =>
-            {
-              'Msf'        => framework,
-              'MsfPayload' => self,
-              'MsfExploit' => assoc_exploit
-            })
-
-        ex = false
-
-        via = via_string_for_ip(ip, comm)
-
-        print_status("Started reverse handler on #{ip}:#{local_port} #{via}")
-        break
-      rescue
-        ex = $!
-        print_error("Handler failed to bind to #{ip}:#{local_port}")
-      end
-    }
-    raise ex if (ex)
-  end
 
   #
   # Closes the listener socket if one was created.
@@ -110,6 +67,13 @@ module ReverseTcp
     conn_threads.each { |thr|
       thr.kill rescue nil
     }
+  end
+
+  # A string suitable for displaying to the user
+  #
+  # @return [String]
+  def human_name
+    "reverse TCP"
   end
 
   #
@@ -246,26 +210,6 @@ module ReverseTcp
   end
 
 protected
-
-  def bind_address
-    # Switch to IPv6 ANY address if the LHOST is also IPv6
-    addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
-    # First attempt to bind LHOST. If that fails, the user probably has
-    # something else listening on that interface. Try again with ANY_ADDR.
-    any = (addr.length == 4) ? "0.0.0.0" : "::0"
-
-    addrs = [ Rex::Socket.addr_ntoa(addr), any  ]
-
-    if not datastore['ReverseListenerBindAddress'].to_s.empty?
-      # Only try to bind to this specific interface
-      addrs = [ datastore['ReverseListenerBindAddress'] ]
-
-      # Pick the right "any" address if either wildcard is used
-      addrs[0] = any if (addrs[0] == "0.0.0.0" or addrs == "::0")
-    end
-
-    addrs
-  end
 
   attr_accessor :listener_sock # :nodoc:
   attr_accessor :listener_thread # :nodoc:

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -2,8 +2,6 @@
 require 'rex/socket'
 require 'thread'
 
-require 'msf/core/handler/reverse_tcp_comm'
-
 module Msf
 module Handler
 

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -235,7 +235,12 @@ module ReverseTcp
     end
 
     if (self.listener_sock)
-      self.listener_sock.close
+      begin
+        self.listener_sock.close
+      rescue IOError
+        # Ignore if it's listening on a dead session
+        dlog("IOError closing listener sock; listening on dead session?", LEV_1)
+      end
       self.listener_sock = nil
     end
   end

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -94,14 +94,7 @@ module ReverseTcp
 
         ex = false
 
-        comm_used = comm || Rex::Socket::SwitchBoard.best_comm( ip )
-        comm_used = Rex::Socket::Comm::Local if comm_used == nil
-
-        if( comm_used.respond_to?( :type ) and comm_used.respond_to?( :sid ) )
-          via = "via the #{comm_used.type} on session #{comm_used.sid}"
-        else
-          via = ""
-        end
+        via = via_string_for_ip(ip, comm)
 
         print_status("Started reverse handler on #{ip}:#{local_port} #{via}")
         break

--- a/lib/msf/core/handler/reverse_tcp_double.rb
+++ b/lib/msf/core/handler/reverse_tcp_double.rb
@@ -45,26 +45,6 @@ module ReverseTcpDouble
   end
 
   #
-  # Starts the listener but does not actually attempt
-  # to accept a connection.  Throws socket exceptions
-  # if it fails to start the listener.
-  #
-  def setup_handler
-    if datastore['Proxies'] and not datastore['ReverseAllowProxy']
-      raise RuntimeError, 'TCP connect-back payloads cannot be used with Proxies. Can be overriden by setting ReverseAllowProxy to true'
-    end
-    self.listener_sock = Rex::Socket::TcpServer.create(
-      # 'LocalHost' => datastore['LHOST'],
-      'LocalPort' => datastore['LPORT'].to_i,
-      'Comm'      => select_comm,
-      'Context'   =>
-        {
-          'Msf'        => framework,
-          'MsfPayload' => self,
-          'MsfExploit' => assoc_exploit
-        })
-  end
-
   #
   # Closes the listener socket if one was created.
   #
@@ -78,6 +58,13 @@ module ReverseTcpDouble
     }
   end
 
+  # A string suitable for displaying to the user
+  #
+  # @return [String]
+  def human_name
+    "reverse TCP double"
+  end
+
   #
   # Starts monitoring for an inbound connection.
   #
@@ -85,8 +72,6 @@ module ReverseTcpDouble
     self.listener_thread = framework.threads.spawn("ReverseTcpDoubleHandlerListener", false) {
       sock_inp = nil
       sock_out = nil
-
-      print_status("Started reverse double handler")
 
       begin
         # Accept two client connection

--- a/lib/msf/core/handler/reverse_tcp_double.rb
+++ b/lib/msf/core/handler/reverse_tcp_double.rb
@@ -15,6 +15,7 @@ module Handler
 module ReverseTcpDouble
 
   include Msf::Handler
+  include Msf::Handler::Reverse
   include Msf::Handler::Reverse::Comm
 
   #
@@ -39,17 +40,6 @@ module ReverseTcpDouble
   #
   def initialize(info = {})
     super
-
-    register_options(
-      [
-        Opt::LHOST,
-        Opt::LPORT(4444)
-      ], Msf::Handler::ReverseTcpDouble)
-
-    register_advanced_options(
-      [
-        OptBool.new('ReverseAllowProxy', [ true, 'Allow reverse tcp even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST', false]),
-      ], Msf::Handler::ReverseTcpDouble)
 
     self.conn_threads = []
   end

--- a/lib/msf/core/handler/reverse_tcp_double.rb
+++ b/lib/msf/core/handler/reverse_tcp_double.rb
@@ -15,6 +15,7 @@ module Handler
 module ReverseTcpDouble
 
   include Msf::Handler
+  include Msf::Handler::Reverse::Comm
 
   #
   # Returns the string representation of the handler type, in this case
@@ -65,7 +66,7 @@ module ReverseTcpDouble
     self.listener_sock = Rex::Socket::TcpServer.create(
       # 'LocalHost' => datastore['LHOST'],
       'LocalPort' => datastore['LPORT'].to_i,
-      'Comm'      => comm,
+      'Comm'      => select_comm,
       'Context'   =>
         {
           'Msf'        => framework,

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -90,14 +90,7 @@ module ReverseTcpDoubleSSL
 
         ex = false
 
-        comm_used = comm || Rex::Socket::SwitchBoard.best_comm( ip )
-        comm_used = Rex::Socket::Comm::Local if comm_used == nil
-
-        if( comm_used.respond_to?( :type ) and comm_used.respond_to?( :sid ) )
-          via = "via the #{comm_used.type} on session #{comm_used.sid}"
-        else
-          via = ""
-        end
+        via = via_string_for_ip(ip, comm)
 
         print_status("Started reverse double SSL handler on #{ip}:#{local_port} #{via}")
         break

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -15,6 +15,7 @@ module Handler
 module ReverseTcpDoubleSSL
 
   include Msf::Handler
+  include Msf::Handler::Reverse
   include Msf::Handler::Reverse::Comm
   include Msf::Handler::Reverse::SSL
 
@@ -41,17 +42,9 @@ module ReverseTcpDoubleSSL
   def initialize(info = {})
     super
 
-    register_options(
-      [
-        Opt::LHOST,
-        Opt::LPORT(4444)
-      ], Msf::Handler::ReverseTcpDoubleSSL)
-
     register_advanced_options(
       [
         OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
-        OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ]),
-        OptBool.new('ReverseAllowProxy', [ true, 'Allow reverse TCP even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST', false]),
       ], Msf::Handler::ReverseTcpDoubleSSL)
 
     self.conn_threads = []
@@ -230,11 +223,6 @@ module ReverseTcpDoubleSSL
   end
 
 protected
-
-  def bind_port
-    port = datastore['ReverseListenerBindPort'].to_i
-    port > 0 ? port : datastore['LPORT'].to_i
-  end
 
   def bind_address
     # Switch to IPv6 ANY address if the LHOST is also IPv6

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -33,7 +33,7 @@ module ReverseTcpDoubleSSL
   end
 
   #
-  # Initializes the reverse TCP handler and ads the options that are required
+  # Initializes the reverse TCP handler and adds the options that are required
   # for all reverse TCP payloads, like local host and local port.
   #
   def initialize(info = {})
@@ -68,20 +68,15 @@ module ReverseTcpDoubleSSL
 
     ex = false
 
-    comm  = datastore['ReverseListenerComm']
-    if comm.to_s == "local"
-      comm = ::Rex::Socket::Comm::Local
-    else
-      comm = nil
-    end
-
+    # Identify the comm to use from
+    # Msf::Handler::ReverseTcpComm.select_comm
+    comm = select_comm
     local_port = bind_port
     addrs = bind_address
 
     addrs.each { |ip|
       begin
 
-        comm.extend(Rex::Socket::SslTcp)
         self.listener_sock = Rex::Socket::SslTcpServer.create(
         'LocalHost' => ip,
         'LocalPort' => local_port,

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -16,6 +16,7 @@ module ReverseTcpDoubleSSL
 
   include Msf::Handler
   include Msf::Handler::Reverse::Comm
+  include Msf::Handler::Reverse::SSL
 
   #
   # Returns the string representation of the handler type, in this case
@@ -51,7 +52,6 @@ module ReverseTcpDoubleSSL
         OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
         OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ]),
         OptBool.new('ReverseAllowProxy', [ true, 'Allow reverse TCP even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST', false]),
-        OptPath.new('HandlerSSLCert', [false, "Path to a SSL certificate in unified PEM format"])
       ], Msf::Handler::ReverseTcpDoubleSSL)
 
     self.conn_threads = []

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -15,6 +15,7 @@ module Handler
 module ReverseTcpDoubleSSL
 
   include Msf::Handler
+  include Msf::Handler::Reverse::Comm
 
   #
   # Returns the string representation of the handler type, in this case
@@ -68,8 +69,6 @@ module ReverseTcpDoubleSSL
 
     ex = false
 
-    # Identify the comm to use from
-    # Msf::Handler::ReverseTcpComm.select_comm
     comm = select_comm
     local_port = bind_port
     addrs = bind_address

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -71,7 +71,6 @@ module ReverseTcpSsl
     addrs.each { |ip|
       begin
 
-        comm.extend(Rex::Socket::SslTcp)
         self.listener_sock = Rex::Socket::SslTcpServer.create(
         'LocalHost' => ip,
         'LocalPort' => local_port,

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -61,10 +61,7 @@ module ReverseTcpSsl
 
     ex = false
 
-    # Identify the comm to use from
-    # Msf::Handler::ReverseTcpComm.select_comm
     comm = select_comm
-
     local_port = bind_port
     addrs = bind_address
 

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -105,33 +105,6 @@ module ReverseTcpSsl
     raise ex if (ex)
   end
 
-protected
-
-  def bind_port
-    port = datastore['ReverseListenerBindPort'].to_i
-    port > 0 ? port : datastore['LPORT'].to_i
-  end
-
-  def bind_address
-    # Switch to IPv6 ANY address if the LHOST is also IPv6
-    addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
-    # First attempt to bind LHOST. If that fails, the user probably has
-    # something else listening on that interface. Try again with ANY_ADDR.
-    any = (addr.length == 4) ? "0.0.0.0" : "::0"
-
-    addrs = [ Rex::Socket.addr_ntoa(addr), any  ]
-
-    if not datastore['ReverseListenerBindAddress'].to_s.empty?
-      # Only try to bind to this specific interface
-      addrs = [ datastore['ReverseListenerBindAddress'] ]
-
-      # Pick the right "any" address if either wildcard is used
-      addrs[0] = any if (addrs[0] == "0.0.0.0" or addrs == "::0")
-    end
-
-    addrs
-  end
-
 end
 
 end

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -69,16 +69,16 @@ module ReverseTcpSsl
       begin
 
         self.listener_sock = Rex::Socket::SslTcpServer.create(
-        'LocalHost' => ip,
-        'LocalPort' => local_port,
-        'Comm'      => comm,
-        'SSLCert'   => datastore['HandlerSSLCert'],
-        'Context'   =>
-          {
-            'Msf'        => framework,
-            'MsfPayload' => self,
-            'MsfExploit' => assoc_exploit
-          })
+          'LocalHost' => ip,
+          'LocalPort' => local_port,
+          'Comm'      => comm,
+          'SSLCert'   => datastore['HandlerSSLCert'],
+          'Context'   =>
+            {
+              'Msf'        => framework,
+              'MsfPayload' => self,
+              'MsfExploit' => assoc_exploit
+            })
 
         ex = false
 

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -2,8 +2,6 @@
 require 'rex/socket'
 require 'thread'
 
-require 'msf/core/handler/reverse_tcp'
-
 module Msf
 module Handler
 
@@ -20,6 +18,7 @@ module Handler
 module ReverseTcpSsl
 
   include Msf::Handler::ReverseTcp
+  include Msf::Handler::Reverse::SSL
 
   #
   # Returns the string representation of the handler type, in this case
@@ -38,25 +37,13 @@ module ReverseTcpSsl
   end
 
   #
-  # Initializes the reverse TCP SSL handler and adds the certificate option.
-  #
-  def initialize(info = {})
-    super
-    register_advanced_options(
-      [
-        OptPath.new('HandlerSSLCert', [false, "Path to a SSL certificate in unified PEM format"])
-      ], Msf::Handler::ReverseTcpSsl)
-
-  end
-
-  #
   # Starts the listener but does not actually attempt
   # to accept a connection.  Throws socket exceptions
   # if it fails to start the listener.
   #
   def setup_handler
     if datastore['Proxies'] and not datastore['ReverseAllowProxy']
-      raise RuntimeError, 'TCP connect-back payloads cannot be used with Proxies. Can be overriden by setting ReverseAllowProxy to true'
+      raise RuntimeError, "TCP connect-back payloads cannot be used with Proxies. Use 'set ReverseAllowProxy true' to override this behaviour."
     end
 
     ex = false

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -69,15 +69,7 @@ module ReverseTcpSsl
 
         ex = false
 
-        comm_used = comm || Rex::Socket::SwitchBoard.best_comm( ip )
-        comm_used = Rex::Socket::Comm::Local if comm_used == nil
-
-        if( comm_used.respond_to?( :type ) and comm_used.respond_to?( :sid ) )
-          via = "via the #{comm_used.type} on session #{comm_used.sid}"
-        else
-          via = ""
-        end
-
+        via = via_string_for_ip(ip, comm)
         print_status("Started reverse SSL handler on #{ip}:#{local_port} #{via}")
         break
       rescue

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
@@ -15,7 +15,6 @@ module Net
 module SocketSubsystem
 
 class TcpServerChannel < Rex::Post::Meterpreter::Channel
-  include Rex::IO::StreamServer
 
   #
   # This is a class variable to store all pending client tcp connections which have not been passed
@@ -25,73 +24,59 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
   #
   @@server_channels = {}
 
-  class << self
-    include Rex::Post::Meterpreter::InboundPacketHandler
+  #
+  # This is the request handler which is registered to the respective meterpreter instance via
+  # Rex::Post::Meterpreter::Extensions::Stdapi::Net::Socket. All incoming requests from the meterpreter
+  # for a 'tcp_channel_open' will be processed here. We create a new TcpClientChannel for each request
+  # received and store it in the respective tcp server channels list of new pending client channels.
+  # These new tcp client channels are passed off via a call the the tcp server channels accept() method.
+  #
+  def self.request_handler(client, packet)
+    return false unless packet.method == "tcp_channel_open"
 
-    #
-    # This is the request handler which is registerd to the respective meterpreter instance via
-    # Rex::Post::Meterpreter::Extensions::Stdapi::Net::Socket. All incoming requests from the meterpreter
-    # for a 'tcp_channel_open' will be processed here. We create a new TcpClientChannel for each request
-    # received and store it in the respective tcp server channels list of new pending client channels.
-    # These new tcp client channels are passed off via a call the the tcp server channels accept() method.
-    #
-    def request_handler( client, packet )
+    cid       = packet.get_tlv_value( TLV_TYPE_CHANNEL_ID )
+    pid       = packet.get_tlv_value( TLV_TYPE_CHANNEL_PARENTID )
+    localhost = packet.get_tlv_value( TLV_TYPE_LOCAL_HOST )
+    localport = packet.get_tlv_value( TLV_TYPE_LOCAL_PORT )
+    peerhost  = packet.get_tlv_value( TLV_TYPE_PEER_HOST )
+    peerport  = packet.get_tlv_value( TLV_TYPE_PEER_PORT )
 
-      if( packet.method == "tcp_channel_open" )
+    return false if cid.nil? || pid.nil?
 
-        cid       = packet.get_tlv_value( TLV_TYPE_CHANNEL_ID )
-        pid       = packet.get_tlv_value( TLV_TYPE_CHANNEL_PARENTID )
-        localhost = packet.get_tlv_value( TLV_TYPE_LOCAL_HOST )
-        localport = packet.get_tlv_value( TLV_TYPE_LOCAL_PORT )
-        peerhost  = packet.get_tlv_value( TLV_TYPE_PEER_HOST )
-        peerport  = packet.get_tlv_value( TLV_TYPE_PEER_PORT )
+    server_channel = client.find_channel(pid)
 
-        if( cid == nil or pid == nil )
-          return false
-        end
+    return false if server_channel.nil?
 
-        server_channel = client.find_channel( pid )
-        if( server_channel == nil )
-          return false
-        end
+    params = Rex::Socket::Parameters.from_hash(
+      {
+        'Proto'     => 'tcp',
+        'LocalHost' => localhost,
+        'LocalPort' => localport,
+        'PeerHost'  => peerhost,
+        'PeerPort'  => peerport,
+        'Comm'      => server_channel.client
+      }
+    )
 
-        params = Rex::Socket::Parameters.from_hash(
-          {
-            'Proto'     => 'tcp',
-            'LocalHost' => localhost,
-            'LocalPort' => localport,
-            'PeerHost'  => peerhost,
-            'PeerPort'  => peerport,
-            'Comm'      => server_channel.client
-          }
-        )
+    client_channel = TcpClientChannel.new(client, cid, TcpClientChannel, CHANNEL_FLAG_SYNCHRONOUS)
 
-        client_channel = TcpClientChannel.new( client, cid, TcpClientChannel, CHANNEL_FLAG_SYNCHRONOUS )
+    client_channel.params = params
 
-        client_channel.params = params
+    @@server_channels[server_channel] ||= ::Queue.new
+    @@server_channels[server_channel].enq(client_channel)
 
-        if( @@server_channels[server_channel] == nil )
-          @@server_channels[server_channel] = []
-        end
+    true
+  end
 
-        @@server_channels[server_channel] << client_channel
-
-        return true
-      end
-
-      return false
-    end
-
-    def cls
-      return CHANNEL_CLASS_STREAM
-    end
-
+  def self.cls
+    CHANNEL_CLASS_STREAM
   end
 
   #
   # Open a new tcp server channel on the remote end.
   #
-  def TcpServerChannel.open(client, params)
+  # @return [Channel]
+  def self.open(client, params)
     c = Channel.create(client, 'stdapi_net_tcp_server', self, CHANNEL_FLAG_SYNCHRONOUS,
       [
         {
@@ -113,7 +98,7 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
   def initialize(client, cid, type, flags)
     super(client, cid, type, flags)
     # add this instance to the class variables dictionary of tcp server channels
-    @@server_channels[self] = []
+    @@server_channels[self] ||= ::Queue.new
   end
 
   #
@@ -121,49 +106,46 @@ class TcpServerChannel < Rex::Post::Meterpreter::Channel
   # and returns nil if no new client connection is available.
   #
   def accept_nonblock
-    result = nil
-    if( @@server_channels[self].length > 0 )
-      channel = @@server_channels[self].shift
-      result = channel.lsock
-    end
-    return result
+    _accept(true)
   end
 
   #
   # Accept a new tcp client connection form this tcp server channel. This method will block indefinatly
   # if no timeout is specified.
   #
-  def accept( opts={} )
-    timeout = opts['Timeout'] || -1
-    if( timeout == -1 )
-      result = _accept
-    else
-      begin
-        ::Timeout.timeout( timeout ) {
-          result = _accept
-        }
-      rescue Timeout::Error
-        result = nil
-      end
+  def accept(opts = {})
+    timeout = opts['Timeout']
+    if (timeout.nil? || timeout <= 0)
+      timeout = 0
     end
-    return result
+
+    result = nil
+    begin
+      ::Timeout.timeout(timeout) {
+        result = _accept
+      }
+    rescue Timeout::Error
+    end
+
+    result
   end
 
 protected
 
-  def _accept
-    while( true )
-      if( @@server_channels[self].empty? )
-        Rex::ThreadSafe.sleep( 0.2 )
-        next
-      end
-      result = accept_nonblock
-      if result != nil
-        result.extend(Rex::Socket::Tcp)
-        break
-      end
+  def _accept(nonblock = false)
+    result = nil
+
+    channel = @@server_channels[self].deq(nonblock)
+
+    if channel
+      result = channel.lsock
     end
-    return result
+
+    if result != nil && !result.kind_of?(Rex::Socket::Tcp)
+      result.extend(Rex::Socket::Tcp)
+    end
+
+    result
   end
 
 end

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/socket_subsystem/tcp_server_channel.rb
@@ -15,6 +15,7 @@ module Net
 module SocketSubsystem
 
 class TcpServerChannel < Rex::Post::Meterpreter::Channel
+  include Rex::IO::StreamServer
 
   #
   # This is a class variable to store all pending client tcp connections which have not been passed
@@ -157,7 +158,10 @@ protected
         next
       end
       result = accept_nonblock
-      break if result != nil
+      if result != nil
+        result.extend(Rex::Socket::Tcp)
+        break
+      end
     end
     return result
   end


### PR DESCRIPTION
Tested working in reverse_tcp and reverse_tcp_double.

One big problem that remains is when a module calls `fail_with`, the handler doesn't seem to clean up correctly and you end up leaving the listener running on the victim with no way to close it.